### PR TITLE
✨ Added a generic N port Adc mux driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,14 @@ project(libhal-soft VERSION 0.0.1 LANGUAGES CXX)
 find_package(libhal REQUIRED CONFIG)
 find_package(libhal-util REQUIRED CONFIG)
 
+if(NOT BUILD_TESTING STREQUAL OFF)
+  add_subdirectory(tests)
+endif()
+
 add_library(libhal-soft
   src/rc_servo.cpp
-  src/i2c_minimum_speed.cpp)
+  src/i2c_minimum_speed.cpp
+  src/adc_mux.cpp)
 
 target_include_directories(libhal-soft PUBLIC include)
 target_compile_features(libhal-soft PRIVATE cxx_std_20)
@@ -29,9 +34,5 @@ target_link_libraries(libhal-soft PRIVATE
   libhal::libhal
   libhal::util
 )
-
-if(NOT BUILD_TESTING STREQUAL OFF)
-  add_subdirectory(tests)
-endif()
 
 install(TARGETS libhal-soft)

--- a/include/libhal-soft/adc_mux.hpp
+++ b/include/libhal-soft/adc_mux.hpp
@@ -1,0 +1,123 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <array>
+#include <libhal-util/map.hpp>
+#include <libhal-util/math.hpp>
+#include <libhal/adc.hpp>
+#include <libhal/error.hpp>
+#include <libhal/output_pin.hpp>
+#include <libhal/steady_clock.hpp>
+#include <span>
+
+using namespace hal::literals;
+using namespace std::chrono_literals;
+
+namespace hal {
+
+// This function does not take into account setup and hold times.
+hal::status set_mux_channel(uint32_t p_position,
+                            std::span<hal::output_pin*> p_signal_pins)
+{
+
+  for (int i = 0; i < static_cast<int>(p_signal_pins.size()); i++) {
+
+    bool value = bool(p_position & (1 << i));
+    HAL_CHECK(p_signal_pins[i]->level(value));
+  }
+  return hal::success();
+}
+
+/**
+ * @brief A driver for Analog to Digital mulitplexers, creates adc pin objects
+ * for each mux output
+ */
+class adc_multiplexer
+{
+public:
+  /**
+   * @brief An internal class of a hal ADC implimentation to represent a
+   * multiplexer pin
+   */
+  class adc_mux_pin : public hal::adc
+  {
+  public:
+    /** @brief An internal constructor to build an adc mux pin.
+     * @param p_mux_port the channel port of the pin on the mux itself.
+     * @param p_mux A pointer to the multiplexer.
+     * */
+    adc_mux_pin(uint8_t p_mux_port, adc_multiplexer* p_mux)
+      : m_mux_port{ p_mux_port }
+      , m_mux{ p_mux } {};  // TODO add m_mux
+
+    /**
+     * @brief Reads the pin.
+     */
+    hal::result<read_t> driver_read() override
+    {
+      return m_mux->read_channel(m_mux_port);
+    }
+
+  private:
+    const uint8_t m_mux_port;
+    adc_multiplexer* m_mux;
+  };
+
+  /**
+   * @param p_signal_pins A span of output pins to represent the signal pins of
+   * the mux, assuming the mux signals digitally.
+   * @param p_source_pin The adc source pin that reads the output of the mux.
+   */
+  adc_multiplexer(std::span<hal::output_pin*> p_signal_pins,
+                  hal::adc* p_source_pin)
+    : m_signal_pins{ p_signal_pins }
+    , m_source_pin{ p_source_pin } {};
+
+  /**
+   * @brief Returns a multiplexer ADC pin
+   * @param p_channel The channel number of the pin.
+   */
+  hal::result<adc_mux_pin> pin_factory(uint8_t p_channel)
+  {
+    // TODO: Ask if we should keep track of channels in use, if a port is asked
+    // for again, disallow it.
+    const std::uint32_t max_size = 1 << m_signal_pins.size();
+    if (p_channel >= max_size) {
+      return hal::new_error(
+        "Unable to add any more pins to this multiplexer.\n");
+    }
+
+    return adc_mux_pin(p_channel, this);
+  }
+
+private:
+  /**
+   * @brief Reads the channel
+   *
+   * @param p_mux_port
+   * @return hal::result<hal::adc::read_t>
+   */
+  hal::result<hal::adc::read_t> read_channel(uint8_t p_mux_port)
+  {
+    set_mux_channel(p_mux_port, m_signal_pins);
+    return HAL_CHECK(m_source_pin->read());
+  }
+
+private:
+  std::span<hal::output_pin*> m_signal_pins;
+  hal::adc* m_source_pin;
+};
+
+}  // namespace hal

--- a/src/adc_mux.cpp
+++ b/src/adc_mux.cpp
@@ -1,0 +1,80 @@
+#include <libhal-soft/adc_mux.hpp>
+#include <libhal-util/steady_clock.hpp>
+
+namespace hal {
+using namespace hal::literals;
+using namespace std::chrono_literals;
+
+namespace {
+/**
+ * @brief Set the ADC mux to a specific channel.
+ *
+ * @param p_position The desired channel.
+ * @param p_signal_pins A span of the source pins.
+ * @param p_clock A steady clock used for delaying 500ns to give time to the mux
+ * to have an updated signal
+ * @return The status of the operation.
+ */
+hal::status set_mux_channel(std::uint16_t p_position,
+                            std::span<output_pin*> p_signal_pins,
+                            hal::steady_clock& p_clock)
+{
+  for (std::size_t i = 0; i < p_signal_pins.size(); i++) {
+    bool value = bool(p_position & (1 << i));
+    hal::delay(p_clock, 500ns);
+    HAL_CHECK(p_signal_pins[i]->level(value));
+  }
+  return success();
+}
+}  // namespace
+
+result<adc_mux_pin> make_adc(adc_multiplexer& p_multiplexer,
+                             std::uint8_t p_channel)
+{
+  if (p_channel > p_multiplexer.get_max_channel()) {
+    return hal::new_error(1);
+  }
+  return adc_mux_pin(p_multiplexer, p_channel);
+}
+
+// Implementations for adc_multiplexer
+
+adc_multiplexer::adc_multiplexer(std::span<output_pin*> p_signal_pins,
+                                 hal::adc& p_source_pin,
+                                 hal::steady_clock& p_clock)
+  : m_signal_pins{ p_signal_pins }
+  , m_source_pin{ &p_source_pin }
+  , m_clock{ &p_clock } {};
+
+adc_multiplexer adc_multiplexer::create(
+  std::span<hal::output_pin*> p_signal_pins,
+  hal::adc& p_source_pin,
+  hal::steady_clock& p_clock)
+{
+  return adc_multiplexer(p_signal_pins, p_source_pin, p_clock);
+}
+
+int adc_multiplexer::get_max_channel()
+{
+  return 1 << this->m_signal_pins.size();
+}
+
+hal::result<hal::adc::read_t> adc_multiplexer::read_channel(
+  std::uint16_t p_mux_port)
+{
+  set_mux_channel(p_mux_port, m_signal_pins, *m_clock);
+  hal::delay(*m_clock, 500ns);
+  return HAL_CHECK(m_source_pin->read());
+}
+
+// Implementations for adc_mux_pin
+
+adc_mux_pin::adc_mux_pin(adc_multiplexer& p_mux, std::uint8_t p_mux_port)
+  : m_mux{ &p_mux }
+  , m_mux_port{ p_mux_port } {};
+
+hal::result<hal::adc::read_t> adc_mux_pin::driver_read()
+{
+  return m_mux->read_channel(m_mux_port);
+}
+}  // namespace hal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(libhal-util REQUIRED CONFIG)
 find_package(libhal-mock REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME}
+  adc_mux.test.cpp
   i2c_minimum_speed.test.cpp
   rc_servo.test.cpp
 

--- a/tests/adc_mux.test.cpp
+++ b/tests/adc_mux.test.cpp
@@ -1,0 +1,93 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../include/libhal-soft/adc_mux.hpp"
+#include <boost/ut.hpp>
+#include <iostream>
+#include <libhal-mock/adc.hpp>
+#include <libhal-mock/output_pin.hpp>
+#include <queue>
+#include <vector>
+
+namespace hal {
+
+void adc_mux_test()
+{
+  using namespace boost::ut;
+  using level_t = hal::output_pin::level_t;
+  using read_t = hal::adc::read_t;
+  using adc_mux_pin = hal::adc_multiplexer::adc_mux_pin;
+  // configure virtual testing pins
+  const int NUM_PINS = 2;
+  std::array<hal::output_pin*, NUM_PINS> signal_pins = { new mock::output_pin,
+                                                         new mock::output_pin };
+  for (auto& s : signal_pins) {
+    s->level() = level_t{ .state = false };
+  }
+
+  mock::adc* source_adc = new mock::adc();
+  auto adc_sample_pool =
+    std::vector<read_t>{ read_t{ .sample = 0 }, read_t{ .sample = 1.5 } };
+  auto sample_queue = std::queue<read_t>();
+  for (auto& s : adc_sample_pool) {
+    sample_queue.push(s);
+  }
+  source_adc->set(sample_queue);
+
+  auto signal_span = std::span<output_pin*>(signal_pins);
+
+  "adc_mux"_test = [signal_span, source_adc]() {
+    // test the adc mux
+    adc_multiplexer test_mux = adc_multiplexer(signal_span, source_adc);
+
+    adc_mux_pin test_adc_port_zero = test_mux.pin_factory(0).value();
+    expect(that % 0 == test_adc_port_zero.read().value().sample);
+  };
+
+  "adc_mux_pin_switch"_test = [signal_span, source_adc]() {
+    adc_multiplexer test_mux = adc_multiplexer(signal_span, source_adc);
+
+    // simulate reading from another pin
+    adc_mux_pin test_adc_port_one = test_mux.pin_factory(1).value();
+    expect(that % 1.5 == test_adc_port_one.read().value().sample);
+    // verify pins were switched
+    expect(that % 1 == signal_span[0]->level().value().state);
+    expect(that % 0 == signal_span[1]->level().value().state);
+  };
+
+  "adc_mux_error"_test = [signal_span, source_adc]() {
+    adc_multiplexer test_mux = adc_multiplexer(signal_span, source_adc);
+
+    auto real_mux_pins =
+      std::array<hal::result<adc_mux_pin>, 4>{ test_mux.pin_factory(0),
+                                               test_mux.pin_factory(1),
+                                               test_mux.pin_factory(2),
+                                               test_mux.pin_factory(3) };
+    auto test_pin = test_mux.pin_factory(4);
+
+    for (auto& p : real_mux_pins) {
+      expect(that % true == p.has_value());
+    }
+
+    expect(that % true == test_pin.has_error());
+  };
+
+  // free virtual pins
+  for (auto s : signal_pins) {
+    delete s;
+  }
+  delete source_adc;
+};
+
+}  // namespace hal

--- a/tests/adc_mux.test.cpp
+++ b/tests/adc_mux.test.cpp
@@ -12,82 +12,130 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../include/libhal-soft/adc_mux.hpp"
-#include <boost/ut.hpp>
-#include <iostream>
-#include <libhal-mock/adc.hpp>
-#include <libhal-mock/output_pin.hpp>
+#include <libhal-soft/adc_mux.hpp>
+
 #include <queue>
 #include <vector>
+
+#include <libhal-mock/adc.hpp>
+#include <libhal-mock/output_pin.hpp>
+#include <libhal-mock/steady_clock.hpp>
+
+#include <boost/ut.hpp>
 
 namespace hal {
 
 void adc_mux_test()
 {
+  // Setup for all tests
   using namespace boost::ut;
+  using namespace hal::literals;
+  using namespace std::chrono_literals;
+
   using level_t = hal::output_pin::level_t;
   using read_t = hal::adc::read_t;
-  using adc_mux_pin = hal::adc_multiplexer::adc_mux_pin;
+  using uptime_t = hal::steady_clock::uptime_t;
+
   // configure virtual testing pins
-  const int NUM_PINS = 2;
-  std::array<hal::output_pin*, NUM_PINS> signal_pins = { new mock::output_pin,
-                                                         new mock::output_pin };
+  constexpr int num_pins = 2;
+  auto mock_pin0 = mock::output_pin();
+  auto mock_pin1 = mock::output_pin();
+  std::array<hal::output_pin*, num_pins> signal_pins = { &mock_pin0,
+                                                         &mock_pin1 };
   for (auto& s : signal_pins) {
     s->level() = level_t{ .state = false };
   }
 
-  mock::adc* source_adc = new mock::adc();
-  auto adc_sample_pool =
-    std::vector<read_t>{ read_t{ .sample = 0 }, read_t{ .sample = 1.5 } };
+  mock::adc source_adc = mock::adc();
+  auto mock_timer = mock::steady_clock();
+  auto update_queue = std::queue<uptime_t>();
+
+  // Simulate clock ticks for mock::steady_clock
+  for (std::uint64_t i = 0; i < 100; i++) {
+    update_queue.push(uptime_t{ .ticks = i });
+  }
+  mock_timer.set_uptimes(update_queue);
+  mock_timer.set_frequency(steady_clock::frequency_t{
+    .operating_frequency = static_cast<hertz>(1 * std::kilo::num) });
+  auto adc_sample_pool = std::array<read_t, 4>{ read_t{ .sample = 0 },
+                                                read_t{ .sample = 1.5 },
+                                                read_t{ .sample = 2 },
+                                                read_t{ .sample = 2.5 } };
   auto sample_queue = std::queue<read_t>();
   for (auto& s : adc_sample_pool) {
     sample_queue.push(s);
   }
-  source_adc->set(sample_queue);
+  source_adc.set(sample_queue);
 
-  auto signal_span = std::span<output_pin*>(signal_pins);
+  // Expected constants
 
-  "adc_mux"_test = [signal_span, source_adc]() {
-    // test the adc mux
-    adc_multiplexer test_mux = adc_multiplexer(signal_span, source_adc);
+  "adc_mux"_test = [signal_pins, source_adc, mock_timer]() mutable {
+    // Setup
+    adc_multiplexer test_mux =
+      adc_multiplexer::create(signal_pins, source_adc, mock_timer);
+    adc_mux_pin test_adc_port_zero = hal::make_adc(test_mux, 0).value();
+    constexpr float expected_sample_zero = 0;
 
-    adc_mux_pin test_adc_port_zero = test_mux.pin_factory(0).value();
-    expect(that % 0 == test_adc_port_zero.read().value().sample);
+    // Exercise
+    auto test_sample = test_adc_port_zero.read().value().sample;
+
+    // Verify
+    expect(that % expected_sample_zero == test_sample);
   };
 
-  "adc_mux_pin_switch"_test = [signal_span, source_adc]() {
-    adc_multiplexer test_mux = adc_multiplexer(signal_span, source_adc);
+  // simulate reading from another pin
+  "adc_mux_pin_switch"_test = [signal_pins, source_adc, mock_timer]() mutable {
+    // Setup
+    adc_multiplexer test_mux =
+      adc_multiplexer::create(signal_pins, source_adc, mock_timer);
+    adc_mux_pin first_mux_pin = hal::make_adc(test_mux, 1).value();
+    adc_mux_pin second_mux_pin = hal::make_adc(test_mux, 2).value();
+    constexpr float expected_sample_zero = 0;
+    constexpr float expected_sample_three_halves = 1.5;
 
-    // simulate reading from another pin
-    adc_mux_pin test_adc_port_one = test_mux.pin_factory(1).value();
-    expect(that % 1.5 == test_adc_port_one.read().value().sample);
-    // verify pins were switched
-    expect(that % 1 == signal_span[0]->level().value().state);
-    expect(that % 0 == signal_span[1]->level().value().state);
+    // Exercise
+    auto first_test_value = first_mux_pin.read().value().sample;
+    auto first_signal_state =
+      std::pair<bool, bool>{ signal_pins[0]->level().value().state,
+                             signal_pins[1]->level().value().state };
+    auto second_test_value = second_mux_pin.read().value().sample;
+    auto second_signal_state =
+      std::pair<bool, bool>{ signal_pins[0]->level().value().state,
+                             signal_pins[1]->level().value().state };
+
+    // Verify
+
+    // Verify the first read value and multiplexer state.
+    expect(that % expected_sample_zero == first_test_value);
+    expect(that % true == first_signal_state.first);
+    expect(that % false == first_signal_state.second);
+
+    // Verify the second read value and multiplexer state.
+    expect(that % expected_sample_three_halves == second_test_value);
+    expect(that % false == second_signal_state.first);
+    expect(that % true == second_signal_state.second);
   };
 
-  "adc_mux_error"_test = [signal_span, source_adc]() {
-    adc_multiplexer test_mux = adc_multiplexer(signal_span, source_adc);
+  "adc_mux_error"_test = [signal_pins, source_adc, mock_timer]() mutable {
+    // Setup
+    adc_multiplexer test_mux =
+      adc_multiplexer::create(signal_pins, source_adc, mock_timer);
 
-    auto real_mux_pins =
-      std::array<hal::result<adc_mux_pin>, 4>{ test_mux.pin_factory(0),
-                                               test_mux.pin_factory(1),
-                                               test_mux.pin_factory(2),
-                                               test_mux.pin_factory(3) };
-    auto test_pin = test_mux.pin_factory(4);
+    // Exercise
+    auto test_read_data = std::array<hal::result<hal::adc::read_t>, 4>{
+      hal::make_adc(test_mux, 0).value().read(),
+      hal::make_adc(test_mux, 1).value().read(),
+      hal::make_adc(test_mux, 2).value().read(),
+      hal::make_adc(test_mux, 3).value().read()
+    };
+    auto error_test = hal::make_adc(test_mux, 4).value().read();
 
-    for (auto& p : real_mux_pins) {
+    // Verify
+    for (auto& p : test_read_data) {
       expect(that % true == p.has_value());
     }
-
-    expect(that % true == test_pin.has_error());
+    expect(that % true == error_test.has_error());
   };
-
-  // free virtual pins
-  for (auto s : signal_pins) {
-    delete s;
-  }
-  delete source_adc;
 };
 
 }  // namespace hal

--- a/tests/libhal.tweaks.hpp
+++ b/tests/libhal.tweaks.hpp
@@ -1,0 +1,21 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string_view>
+
+namespace hal::config {
+constexpr std::string_view platform = "test";
+}  // namespace hal::config

--- a/tests/main.test.cpp
+++ b/tests/main.test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 namespace hal {
+extern void adc_mux_test();
 extern void minimum_speed_test();
 
 extern void inert_accelerometer_test();
@@ -35,6 +36,7 @@ extern void rc_servo_test();
 
 int main()
 {
+  hal::adc_mux_test();
   hal::minimum_speed_test();
 
   hal::inert_accelerometer_test();


### PR DESCRIPTION
This soft driver allows users to use hal::adc objects that represent different input ports on an adc mux. This assumes the mux is controlled using signalling pins and not something like i2c.