### PR TITLE
:green_heart: Fix test_package

### DIFF
--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -12,13 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <libhal-soft/inert_drivers/inert_pwm.hpp>
-#include <libhal-soft/rc_servo.hpp>
+#include <libhal-soft/i2c_minimum_speed.hpp>
+
+namespace hal {
+struct stub_i2c : public hal::i2c
+{
+private:
+  status driver_configure(const settings& p_settings)
+  {
+    return hal::success();
+  }
+  result<transaction_t> driver_transaction(
+    [[maybe_unused]] hal::byte p_address,
+    [[maybe_unused]] std::span<const hal::byte> p_data_out,
+    [[maybe_unused]] std::span<hal::byte> p_data_in,
+    [[maybe_unused]] hal::function_ref<hal::timeout_function> p_timeout)
+  {
+    return transaction_t{};
+  }
+};
+}  // namespace hal
 
 int main()
 {
-  auto pwm = hal::inert_pwm::create().value();
-  auto rc_servo = hal::rc_servo::create(pwm, {});
+  hal::stub_i2c i2c;
+  [[maybe_unused]] auto min_speed_i2c = hal::minimum_speed_i2c::create(i2c);
 
   return 0;
 }


### PR DESCRIPTION
The previous test package got the following error:

```
/usr/bin/ld: /usr/bin/ld: DWARF error: can't find .debug_ranges section.
/home/runner/.conan2/p/libhabd44cf2dbef65/p/lib/liblibhal-soft.a(rc_servo.cpp.o): in function `std::string::_Rep::_M_dispose(std::allocator<char> const&)':
rc_servo.cpp:(.text._ZNSs4_Rep10_M_disposeERKSaIcE[_ZNSs4_Rep10_M_disposeERKSaIcE]+0x47): undefined reference to `__libc_single_threaded'
```

This change uses `minimum_speed_i2c.hpp` instead to mitigate the problem.