### PR TITLE
:green_heart: Add boost-leaf exception handler to test package

### DIFF
--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -22,3 +22,10 @@ int main()
 
   return 0;
 }
+
+namespace boost {
+void throw_exception(std::exception const& e)
+{
+  std::abort();
+}
+}  // namespace boost


### PR DESCRIPTION
This will fix the "undefined reference to `boost::throw_exception(std::exception const&)'" in CI.